### PR TITLE
Resolve with the rejected error

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ function assertRejected(promise, message) {
 		throw new Error("Assertion Error: Promise wasn't rejected");
 	}, function(e) {
 		if (message === undefined)
-			return;
+			return e;
 		if (e.message !== message)
-			throw new Error(wrongMessage(message, e.message))
+			throw new Error(wrongMessage(message, e.message));
+		return e;
 	});
 }
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,13 @@ test("rejected promises should pass", function(t) {
 	return assertRejected(Promise.reject(new Error("Test")));
 });
 
+test("rejected promises should resolve with rejection", function(t) {
+	var error = new Error("Test");
+	return assertRejected(Promise.reject(error)).then(function (x) {
+		if (x !== error) throw new Error("Rejected error not sent to .then(). Received: " + x);
+	});
+});
+
 test("message comparisons are made if specified", function(t) {
 	return assertRejected(Promise.reject(new Error("Test")), "Test");
 });


### PR DESCRIPTION
This allows testing error props such as:

``` js
      const error = await assertRejected(backend.authenticate({ email: 'wrong', password: 'wrong' }))
      assert(error.output.statusCode === 400)
```
