### PR TITLE
added Typescript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ Checks whether a given promise has been rejected
 - `message` : Optionally specify what error the message should contain
 
 Returns a promise which resolves if everything is OK
+
+*Includes typescript typings.*

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+
+declare namespace assertRejected { }
+
+declare function assertRejected(promise: Promise<any>, message?: string): Promise<Error>;
+
+export = assertRejected;


### PR DESCRIPTION
Here are Typescript typings for this helpful little module.

I sought out to ease the pain of asserting thrown errors in `chai`, decided that the main problem with existing solutions was having to wire everything up from multiple packages, and so planned to write my own solution. I thought of a name for it, searched NPM for a package of that name, and voilà! -- your package popped up.

You had already solve my problem.

Almost, anyway. I'm working in Typescript, and I wanted a solution that required installing just one package to do the job. If we add these typings to the package, I've got exactly what I wanted.

Thanks for considering my request! And for already having implemented the thing!